### PR TITLE
Add some missing event types to VnodeData

### DIFF
--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -222,6 +222,14 @@ interface VnodeData {
     'change'?: EventHandler
     'click'?: EventHandler
     'dblclick'?: EventHandler
+    'drag'?: EventHandler
+    'dragend'?: EventHandler
+    'dragenter'?: EventHandler
+    'dragexit'?: EventHandler
+    'dragleave'?: EventHandler
+    'dragover'?: EventHandler
+    'dragstart'?: EventHandler
+    'drop'?: EventHandler
     'focus'?: EventHandler
     'input'?: EventHandler
     'keydown'?: EventHandler


### PR DESCRIPTION
`interface VnodeData` is missing events related to the drag and drop API.