### PR TITLE
Wrapped msg

### DIFF
--- a/src/lib/connectToStore.js
+++ b/src/lib/connectToStore.js
@@ -1,5 +1,6 @@
 import h from 'snabbdom/h'
 import Component from './component'
+import Message from './message'
 import { assign } from './util'
 
 
@@ -10,7 +11,7 @@ export default function connectToStore() {
       return {}
     }
 
-    function connect({ on, props, state }) {
+    function connect({ on, props, state, msg }) {
       const { store } = props()
 
       on(props, unfilteredExternalProps => {
@@ -28,6 +29,7 @@ export default function connectToStore() {
         return assign({}, state(), { mappedProps })
       })
 
+      on(Message.unhandled, m => msg.sendToParent(m))
     }
 
     function render({ state }) {

--- a/test/component.ts
+++ b/test/component.ts
@@ -1043,6 +1043,76 @@ describe('Component', () => {
       .catch(done)
   })
 
+  it('can received a msg from wrapped component', done => {
+
+    const event = Message<MouseEvent>('event')
+
+    const initState = {}
+
+    const store = Store(initState, ({ on, state }) => {})
+
+    type StoreType = typeof store
+
+    type Props = {
+      opt?: string
+    }
+
+    const BaseComponent = (() => {
+
+      function initState() { return {} }
+
+      function connect({on, msg}: ConnectParams<Props, {}>) {
+        on(event, (m: any) => msg.sendToParent(m))
+      }
+
+      function render() {
+        return h('div', {
+          attrs: { 
+            id: 'target'
+          },
+          events: {
+            click: event
+          }
+        })
+      }
+    
+      return function(props: Props) {
+        return Component<Props, {}>({ name: 'baseComponent', props, log: false, initState, connect, render })
+      }
+    })()
+
+    const WrappedComponent = connectToStore<StoreType>()(BaseComponent, store => ({}))
+
+    const ParentComponent = (() => {
+
+      function initState() { return {}}
+
+      function connect({ on }: ConnectParams<Props, {}>) {
+        on(event, evt => {
+          expect(evt.currentTarget).toExist()
+        })
+      }
+
+      function render({ props }: RenderParams<Props, {}>) {
+        return WrappedComponent({store});
+      }
+
+      return function(props: Props) {
+        return Component<Props, {}>({ name: 'parentComponent', props, log: false, initState, connect, render })
+      }
+    })()
+
+    startApp({
+      app: ParentComponent({}),
+      elm: document.body,
+      snabbdomModules
+    })
+
+    const targetDiv = document.getElementById("target")!
+    //console.log(targetDiv) ==> null
+    dispatchMouseEventOn(targetDiv, 'click')
+  })
+
 
   it('can receive a synchronous message inside connect()', done => {
 

--- a/test/component.ts
+++ b/test/component.ts
@@ -1043,9 +1043,9 @@ describe('Component', () => {
       .catch(done)
   })
 
-  it('can received a msg from wrapped component', done => {
+  it('can receive messages from components wrapped with connectToStore', done => {
 
-    const event = Message<MouseEvent>('event')
+    const click = Message<MouseEvent>('click')
 
     const initState = {}
 
@@ -1062,22 +1062,22 @@ describe('Component', () => {
       function initState() { return {} }
 
       function connect({on, msg}: ConnectParams<Props, {}>) {
-        on(event, (m: any) => msg.sendToParent(m))
+        on(click, (m: any) => msg.sendToParent(click(m)))
       }
 
       function render() {
         return h('div', {
-          attrs: { 
+          attrs: {
             id: 'target'
           },
           events: {
-            click: event
+            click
           }
         })
       }
     
       return function(props: Props) {
-        return Component<Props, {}>({ name: 'baseComponent', props, log: false, initState, connect, render })
+        return Component<Props, {}>({ name: 'baseComponent', props, initState, connect, render })
       }
     })()
 
@@ -1088,17 +1088,18 @@ describe('Component', () => {
       function initState() { return {}}
 
       function connect({ on }: ConnectParams<Props, {}>) {
-        on(event, evt => {
+        on(click, evt => {
           expect(evt.currentTarget).toExist()
+          done()
         })
       }
 
       function render({ props }: RenderParams<Props, {}>) {
-        return WrappedComponent({store});
+        return WrappedComponent({store})
       }
 
       return function(props: Props) {
-        return Component<Props, {}>({ name: 'parentComponent', props, log: false, initState, connect, render })
+        return Component<Props, {}>({ name: 'parentComponent', props, initState, connect, render })
       }
     })()
 
@@ -1108,8 +1109,7 @@ describe('Component', () => {
       snabbdomModules
     })
 
-    const targetDiv = document.getElementById("target")!
-    //console.log(targetDiv) ==> null
+    const targetDiv = document.body.firstElementChild!.firstElementChild!.firstElementChild!.firstElementChild!
     dispatchMouseEventOn(targetDiv, 'click')
   })
 


### PR DESCRIPTION
Hi,

with  @denis-mludek we have found an issue preventing a wrapped component into connectToStore to emit event to its parent.
This PR is intended to fix this by forwarding all events to the parent of connectToStore.

However, I have an issue with the test. I can't [get the DOM node](https://github.com/AlexGalays/kaiju/compare/master...dagatsoin:wrappedMsg#diff-4efc82b8ad772b45e9c8a8072664ad69R1112) of the wrapped component to trigger a clic. As you have advised to Denis, I will try to see if my comps are well mounted with some console.log in the render function.