### PR TITLE
[FIX] ConnectToStore : add the baseComponent's name to HOC's name

### DIFF
--- a/src/lib/connectToStore.js
+++ b/src/lib/connectToStore.js
@@ -38,7 +38,7 @@ export default function connectToStore() {
     }
 
     return function connectComponent(props) {
-      return Component({ name: 'connect', log: false, initState, props, connect, render })
+      return Component({ name: `connect-${baseComponent.name}`, log: false, initState, props, connect, render })
     }
 
   }


### PR DESCRIPTION
This prevents the diff algorithm not to render the changes between two siblings because they are wrapped with `connectToStore`.